### PR TITLE
added case-insensitive uniqueness for book names using a database-level unique functional index 

### DIFF
--- a/src/main/java/com/hamadiddi/personal_book_catalog_api/BookController.java
+++ b/src/main/java/com/hamadiddi/personal_book_catalog_api/BookController.java
@@ -1,6 +1,7 @@
 package com.hamadiddi.personal_book_catalog_api;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -66,34 +67,50 @@ public class BookController {
 
     @PutMapping("/{id}")
     public ResponseEntity<?> updateBook(@RequestBody BookReqDto bookReqDto, @PathVariable Long id) {
-        Optional<Book> book = bookRepo.findByNameAndId(bookReqDto.getName(), id);
         Map<String, Object> resp = new HashMap<>();
-        if (book.isPresent()) {
-            resp.put("message", "The book name " + bookReqDto.getName() + " is already present");
+
+        // 1) Check if another book (other than this id) has the same name (case-insensitive)
+        Optional<Book> existing = bookRepo.findByNameIgnoreCase(bookReqDto.getName());
+        if (existing.isPresent() && !existing.get().getId().equals(id)) {
+            resp.put("message", "Book name '" + bookReqDto.getName() + "' already exists");
             resp.put("status", "fail");
-            resp.put("data", null);
             resp.put("code", 409);
-            return ResponseEntity.ok(resp);
-        }
-        Optional<Book> book2 = bookRepo.findById(id);
-        if (book2.isEmpty()) {
-            resp.put("message", "The book with the id " + id + " does not exist");
-            resp.put("status", "fail");
             resp.put("data", null);
-            resp.put("code", 404);
-            return ResponseEntity.ok(resp);
+            return ResponseEntity.status(409).body(resp);
         }
-        Book bookFinal = book2.get();
-        bookFinal.setName(bookReqDto.getName());
-        bookFinal.setAuthor(bookReqDto.getAuthor());
-        bookFinal.setGenre(bookReqDto.getGenre());
 
-        Book bookSaved = bookRepo.save(bookFinal);
+        // 2) Check if this book exists
+        Optional<Book> optionalBook = bookRepo.findById(id);
+        if (optionalBook.isEmpty()) {
+            resp.put("message", "Book with id " + id + " not found");
+            resp.put("status", "fail");
+            resp.put("code", 404);
+            resp.put("data", null);
+            return ResponseEntity.status(404).body(resp);
+        }
 
-        resp.put("message", "The book is updated successfully");
-        resp.put("status", "success");
-        resp.put("data", bookSaved);
-        resp.put("code", 200);
-        return ResponseEntity.ok(resp);
+        Book book = optionalBook.get();
+        book.setName(bookReqDto.getName());
+        book.setAuthor(bookReqDto.getAuthor());
+        book.setGenre(bookReqDto.getGenre());
+
+        //using try-catch to handle multi threading
+        try {
+            Book saved = bookRepo.save(book);
+
+            resp.put("message", "Book updated successfully");
+            resp.put("status", "success");
+            resp.put("code", 200);
+            resp.put("data", saved);
+            return ResponseEntity.ok(resp);
+
+        } catch (DataIntegrityViolationException e) {
+            // DB fallback: functional index lower(name) prevented duplicate
+            resp.put("message", "Book name '" + bookReqDto.getName() + "' already exists");
+            resp.put("status", "fail");
+            resp.put("code", 409);
+            resp.put("data", null);
+            return ResponseEntity.status(409).body(resp);
+        }
     }
 }

--- a/src/main/java/com/hamadiddi/personal_book_catalog_api/BookRepo.java
+++ b/src/main/java/com/hamadiddi/personal_book_catalog_api/BookRepo.java
@@ -9,4 +9,5 @@ public interface BookRepo extends JpaRepository<Book, Long> {
     Optional<Book> findByName(String name);
 
     Optional<Book> findByNameAndId(String name, Long id);
+    Optional<Book> findByNameIgnoreCase(String name);
 }


### PR DESCRIPTION
This change :
- no two books can have the same name regardless of casing
(e.g., garden, Garden, GARDEN → all treated as duplicates)
- Prevents race conditions where two users try to add/update the same book name at the same time.
- Offloads duplicate detection to the database, which is the safest and most reliable place.
- Keeps your database clean without needing a separate “normalized_name” column.

NOTE : create a unique index to optimize name searching and eliminating duplicate names while insertion
```
CREATE UNIQUE INDEX IF NOT EXISTS uq_books_name_lower ON books (lower(name));
```